### PR TITLE
refactor: Use image URL instead of local files

### DIFF
--- a/plugins/main-menu.js
+++ b/plugins/main-menu.js
@@ -59,7 +59,7 @@ const handler = async (m, { conn, usedPrefix: _p }) => {
       }))
 
     let nombreBot = global.namebot || 'Bot'
-    let bannerFinal = './storage/img/Menu3.jpg'
+    let bannerFinal = 'https://files.catbox.moe/tr0lls.jpg'
 
     const botActual = conn.user?.jid?.split('@')[0].replace(/\D/g, '')
     const configPath = join('./JadiBots', botActual, 'config.json')

--- a/plugins/search-tiktok.js
+++ b/plugins/search-tiktok.js
@@ -11,7 +11,7 @@ ${usedPrefix + command} baile divertido
 
   await m.react('🕓')
 
-  let img = './storage/img/menu.jpg'
+  let img = 'https://files.catbox.moe/tr0lls.jpg'
 
   try {
     const { data } = await axios.get(`https://apis-starlights-team.koyeb.app/starlight/tiktoksearch?text=${encodeURIComponent(text)}`)

--- a/plugins/search-youtube.js
+++ b/plugins/search-youtube.js
@@ -11,7 +11,7 @@ ${usedPrefix + command} canción relajante
 
   await m.react('🕒')
 
-  const imgPath = './storage/img/menu.jpg'
+  const imgPath = 'https://files.catbox.moe/tr0lls.jpg'
 
   try {
     const { data } = await axios.get(`https://api.starlights.uk/api/search/youtube?q=${encodeURIComponent(text)}`)


### PR DESCRIPTION
Replaced local image paths with a URL to an image hosted on catbox.moe.

This change affects the following files:
- plugins/main-menu.js
- plugins/search-tiktok.js
- plugins/search-youtube.js